### PR TITLE
Make -v/-q command line args mutually exclusive

### DIFF
--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -107,9 +107,10 @@ def get_experiment(module, experiment=None):
 
 def verbosity_args(parser):
     group = parser.add_argument_group("verbosity")
-    group.add_argument("-v", "--verbose", default=0, action="count",
+    mutually_exclusive_group = group.add_mutually_exclusive_group(required=False)
+    mutually_exclusive_group.add_argument("-v", "--verbose", default=0, action="count",
                        help="increase logging level")
-    group.add_argument("-q", "--quiet", default=0, action="count",
+    mutually_exclusive_group.add_argument("-q", "--quiet", default=0, action="count",
                        help="decrease logging level")
 
 


### PR DESCRIPTION
Fixes m-labs#1102.
User-interface issue, where users could put both -v and -q in to leave logging level unchanged.

Signed-off-by: Drew Risinger <drisinger+github@gmail.com>